### PR TITLE
remove mavimo/phpstan-junit formatter (included in phpstan)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "chubbyphp/chubbyphp-mock": "^1.4.5",
         "doctrine/persistence": "^1.3|^2.0",
         "infection/infection": "^0.15",
-        "mavimo/phpstan-junit": "^0.3",
         "php-coveralls/php-coveralls": "^2.2",
         "phploc/phploc": "^5.0",
         "phpstan/extension-installer": "^1.0.4",


### PR DESCRIPTION
Remove the package `mavimo/phpstan-junit` since the junit reporting format is included in PHPStan starting from [0.12.4](https://github.com/phpstan/phpstan/releases/tag/0.12.4) so no need to extra package 🎉 

Let me know if there is something that you think should be changed here ;)

PS: I really appreciate if you can mark projects in this orgs as `hacktoberfest` "allowed" (mean you need to add a tag to each project with label `hacktoberfest` as reported here https://hacktoberfest.digitalocean.com/hacktoberfest-update )